### PR TITLE
Grant additional permissions in workflows (for Dependabot)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,6 +19,8 @@ env:
 # https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/
 permissions:
   checks: write
+  # If using this template in a private repository, uncomment the following line (otherwise repo checkout fails)
+  # contents: read
   packages: write
 
 jobs:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,6 +15,11 @@ env:
   # You MUST change the value below for your project
   REPOSITORY: firehed/php-registry-template
 
+# Ensure docker-check-action works when run via Dependabot
+# https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/
+permissions:
+  checks: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,6 +19,7 @@ env:
 # https://github.blog/changelog/2021-10-06-github-actions-workflows-triggered-by-dependabot-prs-will-respect-permissions-key-in-workflows/
 permissions:
   checks: write
+  packages: write
 
 jobs:
   build:


### PR DESCRIPTION
This should allow the docker-check-action steps to pass when being run by a Dependabot PR