### PR TITLE
Have dependabot bump composer.json

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    versioning-strategy: increase
 
   # Keep Github Actions up to date
   # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot


### PR DESCRIPTION
Original configuration only bumped `composer.lock`; the `versioning-strategy` setting should cause it to also bump `composer.json` which will decrease the chance of accidentally rolling back a change.